### PR TITLE
Add config persistence and GUI custom curve editor (Phase 4-5)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,10 @@ pub enum Commands {
         /// Example: "0,0,0,1,2,4,6,7,8,10"
         #[arg(long, value_parser = parse_steps)]
         steps: [u8; 10],
+
+        /// Save this curve to fancontrol.json for re-application on startup
+        #[arg(long)]
+        save: bool,
     },
 
     /// Open the graphical fan control interface

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,151 @@
+// put id:"config_load", label:"Load Config (JSON)", output:"config.internal"
+// put id:"config_save", label:"Save Config (JSON)", input:"config.internal"
+
+//! Persistent configuration for custom fan curves.
+//!
+//! Stores `fancontrol.json` next to the executable (same directory as
+//! `fancontrol.log`). Gracefully falls back to defaults on missing or
+//! malformed files.
+
+use std::path::PathBuf;
+
+use log::{info, warn};
+use serde::{Deserialize, Serialize};
+
+use crate::fan::CustomFanCurve;
+
+/// Persistent configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    /// Saved custom fan curves to re-apply on startup.
+    #[serde(default)]
+    pub custom_curves: Vec<CustomFanCurve>,
+
+    /// Automatically switch to Custom SmartFanMode when applying saved curves.
+    #[serde(default = "default_true")]
+    pub auto_smart_fan_mode: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            custom_curves: Vec::new(),
+            auto_smart_fan_mode: true,
+        }
+    }
+}
+
+/// Path to the config file next to the executable.
+pub fn config_path() -> PathBuf {
+    std::env::current_exe()
+        .unwrap_or_default()
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .join("fancontrol.json")
+}
+
+/// Load configuration from disk. Returns defaults on any error.
+pub fn load_config() -> Config {
+    let path = config_path();
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => match serde_json::from_str(&contents) {
+            Ok(config) => {
+                info!("Loaded config from {}", path.display());
+                config
+            }
+            Err(error) => {
+                warn!("Malformed config at {}: {error}", path.display());
+                Config::default()
+            }
+        },
+        Err(_) => Config::default(),
+    }
+}
+
+/// Save configuration to disk.
+pub fn save_config(config: &Config) -> Result<(), std::io::Error> {
+    let path = config_path();
+    let json = serde_json::to_string_pretty(config).map_err(std::io::Error::other)?;
+    std::fs::write(&path, json)?;
+    info!("Saved config to {}", path.display());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_empty_curves() {
+        let config = Config::default();
+        assert!(config.custom_curves.is_empty());
+        assert!(config.auto_smart_fan_mode);
+    }
+
+    #[test]
+    fn roundtrip_serialize() {
+        let config = Config {
+            custom_curves: vec![CustomFanCurve {
+                fan_id: 0,
+                sensor_id: 3,
+                steps: [1, 1, 1, 1, 2, 4, 6, 7, 8, 10],
+            }],
+            auto_smart_fan_mode: true,
+        };
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        let loaded: Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.custom_curves.len(), 1);
+        assert_eq!(loaded.custom_curves[0].fan_id, 0);
+        assert_eq!(
+            loaded.custom_curves[0].steps,
+            [1, 1, 1, 1, 2, 4, 6, 7, 8, 10]
+        );
+    }
+
+    #[test]
+    fn load_empty_json_returns_defaults() {
+        let config: Config = serde_json::from_str("{}").unwrap();
+        assert!(config.custom_curves.is_empty());
+        assert!(config.auto_smart_fan_mode);
+    }
+
+    #[test]
+    fn load_config_from_nonexistent_returns_default() {
+        // config_path() points to exe dir — won't exist in test environment
+        let config = load_config();
+        assert!(config.custom_curves.is_empty());
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("fancontrol.json");
+        let config = Config {
+            custom_curves: vec![
+                CustomFanCurve {
+                    fan_id: 0,
+                    sensor_id: 3,
+                    steps: [1, 1, 1, 1, 2, 4, 6, 7, 8, 10],
+                },
+                CustomFanCurve {
+                    fan_id: 1,
+                    sensor_id: 4,
+                    steps: [0, 0, 1, 2, 3, 5, 7, 8, 9, 10],
+                },
+            ],
+            auto_smart_fan_mode: false,
+        };
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        std::fs::write(&path, json).unwrap();
+        let loaded: Config =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(loaded.custom_curves.len(), 2);
+        assert_eq!(loaded.custom_curves[0], config.custom_curves[0]);
+        assert_eq!(loaded.custom_curves[1], config.custom_curves[1]);
+        assert!(!loaded.auto_smart_fan_mode);
+    }
+}

--- a/src/fan.rs
+++ b/src/fan.rs
@@ -1,6 +1,6 @@
 // put id:"fan_structs", label:"Fan/FanCurve Data Structs", node_type:"database"
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// A single temperature→RPM point in a fan curve.
@@ -57,7 +57,7 @@ pub struct Fan {
 /// into the hardware's FanSpeeds array from `LENOVO_FAN_TABLE_DATA`.
 /// For example, on an 82RG with FanSpeeds = [1600,1800,...,4800]:
 ///   step index 0 → 1600 RPM, step index 9 → 4800 RPM.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub struct CustomFanCurve {
     /// Fan identifier (0 = CPU fan, 1 = GPU fan on V1 hardware).

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -18,7 +18,8 @@ use std::time::Duration;
 use eframe::egui;
 use log::{debug, info, warn};
 
-use crate::fan::{Fan, FanCurve};
+use crate::config;
+use crate::fan::{CustomFanCurve, Fan, FanCurve};
 use crate::platform::create_controller;
 
 // ---------------------------------------------------------------------------
@@ -28,12 +29,17 @@ use crate::platform::create_controller;
 enum WorkerCommand {
     Refresh,
     SetPwm { fan_id: String, pwm: u8 },
+    SetCustomCurve(CustomFanCurve),
+    ClearCustomCurves,
 }
 
 enum WorkerResponse {
     FanData(Vec<Fan>),
     CurveData(HashMap<String, Vec<FanCurve>>),
     PwmSet { fan_id: String, pwm: u8 },
+    CustomCurveSet { fan_id: u32, sensor_id: u32 },
+    CustomCurvesCleared,
+    SmartFanMode(Option<u32>),
     Error(String),
 }
 
@@ -61,11 +67,45 @@ fn spawn_worker(
         // cycle so Fn+Q or other BIOS overrides don't stick.
         let mut held_pwm: HashMap<String, u8> = HashMap::new();
 
+        // Active custom curves. Re-applied each poll cycle (EC fights back).
+        let mut held_curves: Vec<CustomFanCurve> = Vec::new();
+
+        // Load saved curves from config on startup.
+        let saved_config = config::load_config();
+        if !saved_config.custom_curves.is_empty() {
+            info!(
+                "Applying {} saved custom curves from config",
+                saved_config.custom_curves.len()
+            );
+            for curve in &saved_config.custom_curves {
+                if let Err(e) = controller.set_custom_curve(curve) {
+                    warn!(
+                        "Failed to apply saved curve fan={} sensor={}: {e}",
+                        curve.fan_id, curve.sensor_id
+                    );
+                } else {
+                    let _ = response_tx.send(WorkerResponse::CustomCurveSet {
+                        fan_id: curve.fan_id,
+                        sensor_id: curve.sensor_id,
+                    });
+                }
+            }
+            held_curves = saved_config.custom_curves;
+        }
+
+        // Read initial SmartFanMode.
+        match controller.get_smart_fan_mode() {
+            Ok(mode) => {
+                let _ = response_tx.send(WorkerResponse::SmartFanMode(mode));
+            }
+            Err(e) => {
+                debug!("Could not read SmartFanMode: {e}");
+            }
+        }
+
         // Initial discovery — includes curve data on first call.
         match controller.discover() {
             Ok(ref fans) => {
-                // Extract curve data from the first discovery and send
-                // separately so the UI can cache it without re-querying.
                 let mut curves_map: HashMap<String, Vec<FanCurve>> = HashMap::new();
                 for fan in fans {
                     if !fan.curves.is_empty() {
@@ -84,7 +124,6 @@ fn spawn_worker(
         repaint_ctx.request_repaint();
 
         loop {
-            // Wait for a command, or timeout to auto-poll.
             let command = match command_rx.recv_timeout(Duration::from_millis(1500)) {
                 Ok(command) => command,
                 Err(mpsc::RecvTimeoutError::Timeout) => WorkerCommand::Refresh,
@@ -93,11 +132,24 @@ fn spawn_worker(
 
             match command {
                 WorkerCommand::Refresh => {
-                    // Re-apply held PWM values before polling.
+                    // Re-apply held PWM values.
                     for (fan_id, pwm) in &held_pwm {
                         debug!("re-applying held PWM: {fan_id}={pwm}");
                         if let Err(error) = controller.set_pwm(fan_id, *pwm) {
                             warn!("re-apply {fan_id}={pwm} failed: {error}");
+                        }
+                    }
+                    // Re-apply held custom curves (EC fights back on mode changes).
+                    for curve in &held_curves {
+                        debug!(
+                            "re-applying custom curve: fan={} sensor={} steps={:?}",
+                            curve.fan_id, curve.sensor_id, curve.steps
+                        );
+                        if let Err(error) = controller.set_custom_curve(curve) {
+                            warn!(
+                                "re-apply curve fan={} sensor={} failed: {error}",
+                                curve.fan_id, curve.sensor_id
+                            );
                         }
                     }
                     match controller.discover() {
@@ -112,13 +164,16 @@ fn spawn_worker(
                             let _ = response_tx.send(WorkerResponse::Error(error.to_string()));
                         }
                     }
+                    // Periodically refresh SmartFanMode.
+                    if let Ok(mode) = controller.get_smart_fan_mode() {
+                        let _ = response_tx.send(WorkerResponse::SmartFanMode(mode));
+                    }
                 }
                 WorkerCommand::SetPwm { fan_id, pwm } => {
                     info!("user SetPwm: {fan_id}={pwm}");
                     match controller.set_pwm(&fan_id, pwm) {
                         Ok(()) => {
                             if pwm == 0 {
-                                // PWM 0 = return to BIOS auto; stop re-applying.
                                 held_pwm.remove(&fan_id);
                             } else {
                                 held_pwm.insert(fan_id.clone(), pwm);
@@ -132,6 +187,37 @@ fn spawn_worker(
                         }
                     }
                 }
+                WorkerCommand::SetCustomCurve(curve) => {
+                    info!(
+                        "user SetCustomCurve: fan={} sensor={} steps={:?}",
+                        curve.fan_id, curve.sensor_id, curve.steps
+                    );
+                    match controller.set_custom_curve(&curve) {
+                        Ok(()) => {
+                            let fan_id = curve.fan_id;
+                            let sensor_id = curve.sensor_id;
+                            // Replace existing held curve for same fan+sensor.
+                            held_curves
+                                .retain(|c| !(c.fan_id == fan_id && c.sensor_id == sensor_id));
+                            held_curves.push(curve);
+                            let _ = response_tx
+                                .send(WorkerResponse::CustomCurveSet { fan_id, sensor_id });
+                        }
+                        Err(error) => {
+                            warn!("SetCustomCurve failed: {error}");
+                            let _ = response_tx.send(WorkerResponse::Error(error.to_string()));
+                        }
+                    }
+                }
+                WorkerCommand::ClearCustomCurves => {
+                    info!("user ClearCustomCurves");
+                    held_curves.clear();
+                    // Switch back to default SmartFanMode (Balanced = 0).
+                    if let Err(e) = controller.set_smart_fan_mode(0) {
+                        warn!("Reset SmartFanMode failed: {e}");
+                    }
+                    let _ = response_tx.send(WorkerResponse::CustomCurvesCleared);
+                }
             }
 
             repaint_ctx.request_repaint();
@@ -143,11 +229,24 @@ fn spawn_worker(
 // App state
 // ---------------------------------------------------------------------------
 
+/// Editable step sliders for a single fan+sensor custom curve.
+struct CurveEditor {
+    fan_id: u32,
+    sensor_id: u32,
+    steps: [f32; 10],
+}
+
 struct FanControlApp {
     fans: Vec<Fan>,
     slider_values: HashMap<String, f32>,
     /// Curve data per fan, sent once at startup.
     fan_curves: HashMap<String, Vec<FanCurve>>,
+    /// Custom curve editors per fan (keyed by fan_id string).
+    curve_editors: HashMap<String, Vec<CurveEditor>>,
+    /// Current SmartFanMode value.
+    smart_fan_mode: Option<u32>,
+    /// Whether custom curves are active (applied by worker).
+    custom_curves_active: bool,
     status_message: String,
     command_tx: mpsc::Sender<WorkerCommand>,
     response_rx: mpsc::Receiver<WorkerResponse>,
@@ -162,6 +261,9 @@ impl FanControlApp {
             fans: Vec::new(),
             slider_values: HashMap::new(),
             fan_curves: HashMap::new(),
+            curve_editors: HashMap::new(),
+            smart_fan_mode: None,
+            custom_curves_active: false,
             status_message: "Discovering fans...".into(),
             command_tx,
             response_rx,
@@ -183,10 +285,37 @@ impl FanControlApp {
                     self.status_message = "OK".into();
                 }
                 WorkerResponse::CurveData(curves) => {
+                    // Initialize curve editors from discovered curves.
+                    for (fan_key, fan_curves) in &curves {
+                        self.curve_editors
+                            .entry(fan_key.clone())
+                            .or_insert_with(|| {
+                                fan_curves
+                                    .iter()
+                                    .map(|c| CurveEditor {
+                                        fan_id: c.fan_id,
+                                        sensor_id: c.sensor_id,
+                                        steps: [1.0; 10],
+                                    })
+                                    .collect()
+                            });
+                    }
                     self.fan_curves = curves;
                 }
                 WorkerResponse::PwmSet { fan_id, pwm } => {
                     self.status_message = format!("Set {} PWM to {}", fan_id, pwm);
+                }
+                WorkerResponse::CustomCurveSet { fan_id, sensor_id } => {
+                    self.custom_curves_active = true;
+                    self.status_message =
+                        format!("Custom curve applied: fan {} sensor {}", fan_id, sensor_id);
+                }
+                WorkerResponse::CustomCurvesCleared => {
+                    self.custom_curves_active = false;
+                    self.status_message = "Custom curves cleared, returned to BIOS control".into();
+                }
+                WorkerResponse::SmartFanMode(mode) => {
+                    self.smart_fan_mode = mode;
                 }
                 WorkerResponse::Error(message) => {
                     self.status_message = format!("Error: {}", message);
@@ -200,10 +329,31 @@ impl eframe::App for FanControlApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.drain_responses();
 
-        // Top panel — header.
+        // Top panel — header with SmartFanMode indicator.
         egui::TopBottomPanel::top("header").show(ctx, |ui| {
             ui.add_space(4.0);
-            ui.heading("Fan Control");
+            ui.horizontal(|ui| {
+                ui.heading("Fan Control");
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if let Some(mode) = self.smart_fan_mode {
+                        let (mode_label, mode_color) = match mode {
+                            0 => ("Balanced", egui::Color32::from_rgb(100, 180, 100)),
+                            1 => ("Quiet", egui::Color32::from_rgb(100, 150, 220)),
+                            2 => ("Performance", egui::Color32::from_rgb(220, 150, 50)),
+                            3 => ("Custom", egui::Color32::from_rgb(180, 100, 220)),
+                            _ => ("Unknown", egui::Color32::GRAY),
+                        };
+                        ui.colored_label(mode_color, format!("SmartFanMode: {mode_label}"));
+                    }
+                    if self.custom_curves_active {
+                        ui.colored_label(
+                            egui::Color32::from_rgb(180, 100, 220),
+                            "Custom Curves Active",
+                        );
+                        ui.separator();
+                    }
+                });
+            });
             ui.add_space(4.0);
         });
 
@@ -281,7 +431,7 @@ impl eframe::App for FanControlApp {
                             ui.label("read-only");
                         }
 
-                        // Collapsible fan curve section.
+                        // Collapsible fan curve section with custom curve editor.
                         if let Some(curves) = self.fan_curves.get(&fan.id) {
                             if !curves.is_empty() {
                                 ui.add_space(4.0);
@@ -322,6 +472,98 @@ impl eframe::App for FanControlApp {
                                             );
 
                                             ui.add_space(4.0);
+                                        }
+
+                                        // Custom curve editor.
+                                        ui.separator();
+                                        ui.strong("Custom Curve Editor");
+                                        ui.label("Set 10 speed step indices (0\u{2013}10)");
+
+                                        if let Some(editors) = self.curve_editors.get_mut(&fan.id) {
+                                            for editor in editors.iter_mut() {
+                                                ui.label(format!(
+                                                    "Fan {} \u{2192} Sensor {}",
+                                                    editor.fan_id, editor.sensor_id
+                                                ));
+
+                                                egui::Grid::new(format!(
+                                                    "editor_{}_{}",
+                                                    editor.fan_id, editor.sensor_id
+                                                ))
+                                                .show(ui, |ui| {
+                                                    for i in 0..10 {
+                                                        ui.label(format!("S{i}:"));
+                                                        ui.add(
+                                                            egui::Slider::new(
+                                                                &mut editor.steps[i],
+                                                                0.0..=10.0,
+                                                            )
+                                                            .step_by(1.0)
+                                                            .fixed_decimals(0),
+                                                        );
+                                                        if i == 4 {
+                                                            ui.end_row();
+                                                        }
+                                                    }
+                                                    ui.end_row();
+                                                });
+
+                                                ui.horizontal(|ui| {
+                                                    if ui.button("Apply").clicked() {
+                                                        let steps: [u8; 10] =
+                                                            std::array::from_fn(|i| {
+                                                                editor.steps[i] as u8
+                                                            });
+                                                        let _ = self.command_tx.send(
+                                                            WorkerCommand::SetCustomCurve(
+                                                                CustomFanCurve {
+                                                                    fan_id: editor.fan_id,
+                                                                    sensor_id: editor.sensor_id,
+                                                                    steps,
+                                                                },
+                                                            ),
+                                                        );
+                                                    }
+                                                    if ui.button("Save").clicked() {
+                                                        let steps: [u8; 10] =
+                                                            std::array::from_fn(|i| {
+                                                                editor.steps[i] as u8
+                                                            });
+                                                        let curve = CustomFanCurve {
+                                                            fan_id: editor.fan_id,
+                                                            sensor_id: editor.sensor_id,
+                                                            steps,
+                                                        };
+                                                        let _ = self.command_tx.send(
+                                                            WorkerCommand::SetCustomCurve(
+                                                                curve.clone(),
+                                                            ),
+                                                        );
+                                                        // Persist to config.
+                                                        let mut cfg = config::load_config();
+                                                        cfg.custom_curves.retain(|c| {
+                                                            !(c.fan_id == editor.fan_id
+                                                                && c.sensor_id == editor.sensor_id)
+                                                        });
+                                                        cfg.custom_curves.push(curve);
+                                                        if let Err(e) = config::save_config(&cfg) {
+                                                            self.status_message =
+                                                                format!("Save failed: {e}");
+                                                        }
+                                                    }
+                                                    if ui.button("Reset to BIOS").clicked() {
+                                                        let _ = self
+                                                            .command_tx
+                                                            .send(WorkerCommand::ClearCustomCurves);
+                                                        // Clear saved curves from config too.
+                                                        let mut cfg = config::load_config();
+                                                        cfg.custom_curves.clear();
+                                                        let _ = config::save_config(&cfg);
+                                                    }
+                                                });
+
+                                                ui.add_space(4.0);
+                                            }
                                         }
                                     });
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod config;
 mod errors;
 mod fan;
 mod gui;
@@ -67,7 +68,8 @@ fn main() -> Result<()> {
                     fan_id,
                     sensor_id,
                     steps,
-                } => cmd_set_curve(&*controller, fan_id, sensor_id, steps),
+                    save,
+                } => cmd_set_curve(&*controller, fan_id, sensor_id, steps, save),
                 Commands::Gui | Commands::Tui => unreachable!(),
             }
         }
@@ -209,6 +211,7 @@ fn cmd_set_curve(
     fan_id: u32,
     sensor_id: u32,
     steps: [u8; 10],
+    save: bool,
 ) -> Result<()> {
     let curve = CustomFanCurve {
         fan_id,
@@ -223,9 +226,21 @@ fn cmd_set_curve(
         fan_id, sensor_id
     );
     println!("Steps: {:?}", steps);
-    println!();
-    println!("Note: Custom curves require SmartFanMode=Custom and are volatile");
-    println!("      (lost on reboot, sleep, or power mode change).");
+
+    if save {
+        let mut cfg = config::load_config();
+        // Replace any existing curve for the same fan+sensor, or add new.
+        cfg.custom_curves
+            .retain(|c| !(c.fan_id == fan_id && c.sensor_id == sensor_id));
+        cfg.custom_curves.push(curve);
+        config::save_config(&cfg)?;
+        println!("Saved to {}", config::config_path().display());
+    } else {
+        println!();
+        println!("Note: Custom curves require SmartFanMode=Custom and are volatile");
+        println!("      (lost on reboot, sleep, or power mode change).");
+        println!("      Use --save to persist to fancontrol.json.");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- **Phase 4**: Persistent config file (`fancontrol.json`) with `--save` flag on `set-curve` CLI command
- **Phase 5**: GUI custom curve editor with 10 step sliders, Apply/Save/Reset buttons, SmartFanMode indicator, and automatic curve re-application on startup

Builds on PR #15 (JSON + TUI). Closes #14.

## Changes

### New files
- `src/config.rs` — Config struct, JSON load/save next to executable, 5 unit tests

### Modified files
- `src/fan.rs` — Add Serialize/Deserialize/PartialEq to CustomFanCurve
- `src/cli.rs` — Add `--save` flag to `set-curve` subcommand
- `src/main.rs` — Wire up config module, pass `--save` through to cmd_set_curve
- `src/gui.rs` — Worker thread: load saved curves, SetCustomCurve/ClearCustomCurves commands, re-apply each poll cycle. UI: SmartFanMode indicator, 10 step sliders per fan/sensor, Apply/Save/Reset buttons

### Architecture
- Worker thread re-applies custom curves every 1.5s poll cycle (same pattern as `held_pwm`) to resist BIOS/EC overrides
- Config is loaded once on worker startup; GUI Save button persists immediately
- Reset to BIOS clears both held curves and saved config, restores SmartFanMode to Balanced (0)

## Test plan
- [x] 52 tests pass (`cargo test`)
- [x] Zero clippy warnings
- [x] Format clean
- [x] Linux build succeeds
- [x] Windows cross-compile succeeds
- [ ] Manual test: GUI launches, sliders visible in fan curve section
- [ ] Manual test: Apply sends curve to worker, fan behavior changes above threshold temps
- [ ] Manual test: Save creates fancontrol.json, curves restored on next GUI launch
- [ ] Manual test: Reset clears curves and switches back to BIOS control

🤖 Generated with [Claude Code](https://claude.com/claude-code)